### PR TITLE
Fixes confusion of years as number of affected people

### DIFF
--- a/scrape_newspapers/get_impact_data.py
+++ b/scrape_newspapers/get_impact_data.py
@@ -738,9 +738,16 @@ def main(config_file, input_filename=None, output_filename_base=None):
             for ent in ents:
                 # get entity text and clean it
                 ent_text = re.sub('\n', '', ent.text).strip()
-                # check if empty entity text or entity text is a year
-                if ent_text == '' or re.search('(20(?!00)[0-9]{2})', ent_text):
+                # check if empty entity text
+                if ent_text == '':
                     continue
+                # check if number is a year
+                try:
+                    if int(ent_text) in range(2001,2041):
+                        continue
+                except ValueError:
+                    pass
+
                 number = '' # number associated to entity
                 addendum = '' # extra info (currency or object)
                 impact_label = '' # label specifying the nature of the impact data


### PR DESCRIPTION
- The number is checked to be a year before checking if it is a monetary value, since most damages will be higher then 2000-2099.
- The year 2000 is skipped because all 'millier' (some thousands) is instantiated as 2000
- Does not check if word was originally fully written out (which would probably mean it is not a year). Do not do this, because seems like 2001-2099 will probably never be written out.

