### PR TITLE
dont write out the indexes to csv

### DIFF
--- a/scrape_newspapers/scrape_articles.py
+++ b/scrape_newspapers/scrape_articles.py
@@ -243,7 +243,7 @@ def main(config_file):
         output_name = 'articles_{keyword}_{news_name}.csv'.format(
             keyword=config['keyword'], news_name=news_name)
         output_dir_news = os.path.join(output_dir, output_name)
-        articles_news.to_csv(output_dir_news, sep='|')
+        articles_news.to_csv(output_dir_news, sep='|', index=False)
 
     print("\nFINISHED PROCESSING *****************************")
     # print("\nSummary")


### PR DESCRIPTION
The inspect_articles script had problems finding the right title of the article to assess for topical (yes/no), due to wrong indexing in the scrape_articles script. It messed it up. Removed the indexing in scrape_articles and fixed the problem.