### PR TITLE
Added catch for WebDriverException

### DIFF
--- a/scrape_newspapers/scrape_articles.py
+++ b/scrape_newspapers/scrape_articles.py
@@ -11,7 +11,7 @@ from newspaper import Article
 from selenium.webdriver import Firefox
 from selenium.webdriver.firefox.options import Options
 from selenium.common.exceptions import \
-    NoSuchElementException, TimeoutException, InvalidArgumentException
+    NoSuchElementException, TimeoutException, InvalidArgumentException, WebDriverException
 import pandas as pd
 pd.set_option('display.max_columns', 4)
 pd.set_option('max_colwidth', 20)
@@ -194,7 +194,7 @@ def main(config_file):
         news_url += '?s='+config['keyword']
         try:
             browser.get(news_url)
-        except TimeoutException:
+        except (TimeoutException, WebDriverException):
             print('Unable to access, skipping')
             continue
 


### PR DESCRIPTION
It seems that [Journal du Mali](https://www.journaldumali.com/) is no longer accessible and throws a `WebDriverException`, here a catch is implemented so that the article scraper doesn't crash 