### PR TITLE
Add exceptions for second call of browser.get

### DIFF
--- a/scrape_newspapers/scrape_articles.py
+++ b/scrape_newspapers/scrape_articles.py
@@ -263,7 +263,7 @@ def main(config_file, debug=False):
                     logger.info('{}'.format(search_result_next_page[0]))
                     try:
                         browser.get(search_result_next_page[0])
-                    except (NoSuchElementException, TimeoutException, InvalidArgumentException):
+                    except NoSuchElementException:
                         logger.error("Can't open page, abandoning news source")
                         break
             except (TimeoutException, InvalidArgumentException):


### PR DESCRIPTION
When looping over additional pages in the article scraping, `browser.get` may get called a second time if regex is needed to access the subsequent pages, however unlike for the first call, there is no attempt to catch common exceptions. This is in fact necessary (the case I ran into was for page 27 of Kouloumba.com) so I've added it in. 