### PR TITLE
Add to blacklist

### DIFF
--- a/scrape_newspapers/scrape_articles.py
+++ b/scrape_newspapers/scrape_articles.py
@@ -222,7 +222,6 @@ def main(config_file, debug=False):
 
     # blacklist
     del Newspapers['Niarela']
-    del Newspapers['Journal du Mali']
 
     # loop over newspapers
     for news_name, news_url in Newspapers.items():


### PR DESCRIPTION
- Browser did not work headless yet

- Add Journal du Mali to blacklist since it can often not be reached

*UPDATE:
Decided not to add Journal du Mali to blacklist
